### PR TITLE
Revert "APIKIT-2839: Unable to parse AMF model - OutOfMemoryError (#1…

### DIFF
--- a/interface-impl-amf/src/main/java/org/mule/amf/impl/model/AMFImpl.java
+++ b/interface-impl-amf/src/main/java/org/mule/amf/impl/model/AMFImpl.java
@@ -16,9 +16,6 @@ import amf.client.render.Raml08Renderer;
 import amf.client.render.Raml10Renderer;
 import amf.client.render.RenderOptions;
 import amf.client.render.Renderer;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.nio.charset.Charset;
 import org.mule.amf.impl.parser.factory.AMFParserWrapper;
 import org.mule.amf.impl.util.LazyValue;
 import org.mule.apikit.ApiType;
@@ -30,7 +27,6 @@ import org.mule.apikit.model.Template;
 import org.mule.apikit.model.parameter.Parameter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.yaml.builder.JsonOutputBuilder;
 import scala.Option;
 
 import java.net.URI;
@@ -41,7 +37,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
-import org.mulesoft.common.io.Output;
 
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
@@ -217,24 +212,6 @@ public class AMFImpl implements ApiSpecification {
           .get();
     } catch (InterruptedException | ExecutionException e) {
       return e.getMessage();
-    }
-  }
-
-  public void writeAMFModel(OutputStream outputStream) {
-    try {
-      OutputStreamWriter writer = new OutputStreamWriter(outputStream, Charset.forName("UTF-8"));
-      new AmfGraphRenderer()
-          .generateToBuilder(consoleModel.get(),
-                             new RenderOptions()
-                                 .withoutSourceMaps()
-                                 .withoutPrettyPrint()
-                                 .withCompactUris(),
-                             new JsonOutputBuilder<>(writer, false,
-                                                     Output.outputWriter()))
-          .get();
-      writer.close();
-    } catch (Exception e) {
-      throw new RuntimeException("Error trying to dump AMF model", e);
     }
   }
 

--- a/interface-impl-amf/src/test/java/org/mule/amf/impl/model/AMFImplTest.java
+++ b/interface-impl-amf/src/test/java/org/mule/amf/impl/model/AMFImplTest.java
@@ -6,10 +6,6 @@
  */
 package org.mule.amf.impl.model;
 
-import java.io.IOException;
-import java.io.PipedInputStream;
-import java.io.PipedOutputStream;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.junit.Before;
@@ -22,12 +18,10 @@ import org.mule.apikit.model.api.ApiReference;
 import java.io.File;
 import java.net.URI;
 
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class AMFImplTest {
@@ -183,13 +177,4 @@ public class AMFImplTest {
     assertEquals(BASE_URI, api.getBaseUri());
   }
 
-  @Test
-  public void streamAMFModel() throws IOException {
-    PipedOutputStream pipedOutputStream = new PipedOutputStream();
-    PipedInputStream pipedInputStream = new PipedInputStream(pipedOutputStream);
-    Thread thread = new Thread(() -> api.writeAMFModel(pipedOutputStream));
-    thread.start();
-    String model = IOUtils.toString(pipedInputStream);
-    assertThat(model, containsString("https://{apiDomain}.ec2.amazonaws.com"));
-  }
 }


### PR DESCRIPTION
…79) (#186)"

This reverts commit 5fc2e9a19f66d9804f29a6df2af4ed0942d29897.