### PR TITLE
W-11330436: Remove rhino exclusion

### DIFF
--- a/interface-impl-v1/pom.xml
+++ b/interface-impl-v1/pom.xml
@@ -32,10 +32,6 @@
                     <groupId>commons-io</groupId>
                     <artifactId>commons-io</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>org.mozilla</groupId>
-                    <artifactId>rhino</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -47,11 +43,6 @@
             <groupId>org.mule.apikit</groupId>
             <artifactId>raml-parser-interface</artifactId>
             <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.mozilla</groupId>
-            <artifactId>rhino</artifactId>
-            <version>${rhino.version}</version>
         </dependency>
     </dependencies>
 

--- a/interface-impl-v1/pom.xml
+++ b/interface-impl-v1/pom.xml
@@ -17,7 +17,7 @@
         <formatterConfigPath>../formatter.xml</formatterConfigPath>
         <sonar.jacoco.reportPaths>../target/jacoco.exec</sonar.jacoco.reportPaths>
 
-        <raml.parser.version>0.8.43</raml.parser.version>
+        <raml.parser.version>0.8.44</raml.parser.version>
         <commons.io.version>2.7</commons.io.version>
     </properties>
 

--- a/interface-impl-v2/pom.xml
+++ b/interface-impl-v2/pom.xml
@@ -26,22 +26,11 @@
             <groupId>org.raml</groupId>
             <artifactId>raml-parser-2</artifactId>
             <version>${raml.parser.2.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.mozilla</groupId>
-                    <artifactId>rhino</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.mule.apikit</groupId>
             <artifactId>raml-parser-interface</artifactId>
             <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.mozilla</groupId>
-            <artifactId>rhino</artifactId>
-            <version>${rhino.version}</version>
         </dependency>
     </dependencies>
 

--- a/interface-impl-v2/pom.xml
+++ b/interface-impl-v2/pom.xml
@@ -18,7 +18,7 @@
         <formatterConfigPath>../formatter.xml</formatterConfigPath>
         <sonar.jacoco.reportPaths>../target/jacoco.exec</sonar.jacoco.reportPaths>
 
-        <raml.parser.2.version>1.0.44-2</raml.parser.2.version>
+        <raml.parser.2.version>1.0.44-3</raml.parser.2.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,6 @@
 
         <mule.metadata.api.version>1.1.0</mule.metadata.api.version>
 
-        <rhino.version>1.7.14</rhino.version>
         <jackson.databind.version>2.13.3</jackson.databind.version>
         <guava.version>31.1-jre</guava.version>
         <json.version>20220320</json.version>


### PR DESCRIPTION
This exclusion was added because of W-11330436 as a temporary measure until W-11331005 is completed. W-11331005 was completed so we can now bump our parser versions and remove the unneeded exclusions.