### PR TITLE
W-12113783: Return all validation errors instead of just the first one

### DIFF
--- a/interface-impl-amf/src/main/java/org/mule/amf/impl/model/ParameterImpl.java
+++ b/interface-impl-amf/src/main/java/org/mule/amf/impl/model/ParameterImpl.java
@@ -104,11 +104,12 @@ class ParameterImpl implements Parameter {
   }
 
   private String getErrorMessageFromReport(AMFValidationReport validationReport) {
-    return validationReport.conforms() ? "OK"
-        : validationReport.results().stream()
-            .findFirst()
+    return validationReport.conforms()
+        ? "OK"
+        : validationReport.results()
+            .stream()
             .map(AMFValidationResult::message)
-            .orElse("Error");
+            .collect(joining("\n"));
   }
 
   @Override

--- a/interface-impl-amf/src/test/java/org/mule/amf/impl/model/ParameterImplTest.java
+++ b/interface-impl-amf/src/test/java/org/mule/amf/impl/model/ParameterImplTest.java
@@ -64,7 +64,7 @@ public class ParameterImplTest {
   public ApiSpecification apiSpecification;
 
   @Parameterized.Parameters(name = "{0}")
-  public static Collection<Object[]> apiSpecifications() throws Exception {
+  public static Collection<Object[]> apiSpecifications() {
     ApiReference ramlApiRef = getApiReference("../10-query-parameters/api.raml");
     ApiReference oas20apiRef = getApiReference("../oas20-query-parameters/api.yaml");
     ApiReference oas30apiRef = getApiReference("../oas30-query-parameters/api.yaml");
@@ -76,9 +76,13 @@ public class ParameterImplTest {
     });
   }
 
-  private static ApiReference getApiReference(String resourceName) throws URISyntaxException {
-    URI uri = ParameterImplTest.class.getResource(resourceName).toURI();
-    return ApiReference.create(uri);
+  private static ApiReference getApiReference(String resourceName) {
+    try {
+      URI uri = ParameterImplTest.class.getResource(resourceName).toURI();
+      return ApiReference.create(uri);
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   @Before

--- a/interface-impl-amf/src/test/java/org/mule/amf/impl/model/ParameterImplTest.java
+++ b/interface-impl-amf/src/test/java/org/mule/amf/impl/model/ParameterImplTest.java
@@ -158,7 +158,7 @@ public class ParameterImplTest {
 
   @Test
   public void validateSpecialCharacters() {
-    final Parameter parameter = queryParams.get(ISBN_QUERY_PARAM);
+    final Parameter parameter = testNullQueryParams.get("nonNullableString");
     assertTrue(parameter.validate("\\TestTest1"));
     assertTrue(parameter.validate("Test%3A%20Test\\"));
     assertTrue(parameter.validate("\"foo\" is not \"bar\". specials: \b\r\n\f\t\\/"));

--- a/interface-impl-amf/src/test/java/org/mule/amf/impl/model/ParameterImplTest.java
+++ b/interface-impl-amf/src/test/java/org/mule/amf/impl/model/ParameterImplTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -350,6 +351,27 @@ public class ParameterImplTest {
   @Test
   public void filePropertiesIsEmptyWhenParameterIsNotFile() {
     assertFalse(queryParams.get(AUTHOR_QUERY_PARAM).getFileProperties().isPresent());
+  }
+
+  @Test
+  public void validationCanReportMultipleErrorMessages() {
+    Parameter isbn = queryParams.get(ISBN_QUERY_PARAM);
+
+    String doesNotMatch = "string [%s] does not match pattern ^[-\\d]*$";
+    String tooShort = "expected minLength: 10, actual: %d";
+    String tooLong = "expected maxLength: 17, actual: %d";
+
+
+    String shortInvalidValue = "SHORT";
+    String shortErrorMessage = format(doesNotMatch + "\n" + tooShort, shortInvalidValue, shortInvalidValue.length());
+    assertFalse(isbn.validate(shortInvalidValue));
+    assertEquals(shortErrorMessage, isbn.message(shortInvalidValue));
+
+    String longInvalidValue = String.format("%20s", "LONG");
+    String longErrorMessage = format(doesNotMatch + "\n" + tooLong, longInvalidValue, longInvalidValue.length());
+
+    assertFalse(isbn.validate(longInvalidValue));
+    assertEquals(longErrorMessage, isbn.message(longInvalidValue));
   }
 
 }

--- a/interface-impl-amf/src/test/java/org/mule/amf/impl/model/ParameterImplTest.java
+++ b/interface-impl-amf/src/test/java/org/mule/amf/impl/model/ParameterImplTest.java
@@ -17,6 +17,8 @@ import org.mule.apikit.model.api.ApiReference;
 import org.mule.apikit.model.parameter.FileProperties;
 import org.mule.apikit.model.parameter.Parameter;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -61,21 +63,21 @@ public class ParameterImplTest {
   public ApiSpecification apiSpecification;
 
   @Parameterized.Parameters(name = "{0}")
-  public static Collection apiSpecifications() throws Exception {
-    String apiLocation = ParameterImplTest.class.getResource("../10-query-parameters/api.raml").toURI().toString();
-    ApiReference ramlApiRef = ApiReference.create(apiLocation);
-
-    apiLocation = ParameterImplTest.class.getResource("../oas20-query-parameters/api.yaml").toURI().toString();
-    ApiReference oas20apiRef = ApiReference.create(apiLocation);
-
-    apiLocation = ParameterImplTest.class.getResource("../oas30-query-parameters/api.yaml").toURI().toString();
-    ApiReference oas30apiRef = ApiReference.create(apiLocation);
+  public static Collection<Object[]> apiSpecifications() throws Exception {
+    ApiReference ramlApiRef = getApiReference("../10-query-parameters/api.raml");
+    ApiReference oas20apiRef = getApiReference("../oas20-query-parameters/api.yaml");
+    ApiReference oas30apiRef = getApiReference("../oas30-query-parameters/api.yaml");
 
     return asList(new Object[][] {
-        {ApiVendor.RAML, new AMFParser(ramlApiRef, true).parse()},
-        {ApiVendor.OAS_20, new AMFParser(oas20apiRef, true).parse()},
-        {ApiVendor.OAS_30, new AMFParser(oas30apiRef, true).parse()}
+        {ApiVendor.RAML, new AMFParser(ramlApiRef).parse()},
+        {ApiVendor.OAS_20, new AMFParser(oas20apiRef).parse()},
+        {ApiVendor.OAS_30, new AMFParser(oas30apiRef).parse()}
     });
+  }
+
+  private static ApiReference getApiReference(String resourceName) throws URISyntaxException {
+    URI uri = ParameterImplTest.class.getResource(resourceName).toURI();
+    return ApiReference.create(uri);
   }
 
   @Before
@@ -92,10 +94,8 @@ public class ParameterImplTest {
   @Test
   public void nonNullableInteger() {
     final Parameter nonNullableInteger = testNullQueryParams.get("nonNullableInteger");
-    if (!ApiVendor.OAS_20.equals(apiVendor)) {
-      assertFalse(nonNullableInteger.validate(null));
-      assertEquals("expected type: Integer, found: Null", nonNullableInteger.message(null));
-    }
+    assertFalse(nonNullableInteger.validate(null));
+    assertEquals("expected type: Integer, found: Null", nonNullableInteger.message(null));
     assertTrue(nonNullableInteger.validate("123"));
   }
 
@@ -111,10 +111,8 @@ public class ParameterImplTest {
   @Test
   public void nonNullableString() {
     final Parameter nonNullableString = testNullQueryParams.get("nonNullableString");
-    if (!ApiVendor.OAS_20.equals(apiVendor)) {
-      assertFalse(nonNullableString.validate(null));
-      assertEquals("expected type: String, found: Null", nonNullableString.message(null));
-    }
+    assertFalse(nonNullableString.validate(null));
+    assertEquals("expected type: String, found: Null", nonNullableString.message(null));
     assertTrue(nonNullableString.validate("123"));
   }
 
@@ -140,10 +138,8 @@ public class ParameterImplTest {
   @Test
   public void nonNullableArray() {
     final Parameter nonNullableString = testNullQueryParams.get("nonNullableArray");
-    if (!ApiVendor.OAS_20.equals(apiVendor)) {
-      assertFalse(nonNullableString.validateArray(null));
-      assertEquals("expected type: JSONArray, found: Null", nonNullableString.messageFromValues(null));
-    }
+    assertFalse(nonNullableString.validateArray(null));
+    assertEquals("expected type: JSONArray, found: Null", nonNullableString.messageFromValues(null));
     assertTrue(nonNullableString.validateArray(asList("Hola", "Mundo")));
   }
 
@@ -260,10 +256,12 @@ public class ParameterImplTest {
   @Test
   public void getExamplesTest() {
     assertEquals(0, queryParams.get(PUBLICATION_YEAR_QUERY_PARAM).getExamples().size());
-    if (!ApiVendor.OAS_20.equals(apiVendor)) {
-      assertEquals(2, queryParams.get(AUTHOR_QUERY_PARAM).getExamples().size());
+    int exampleCount = queryParams.get(AUTHOR_QUERY_PARAM).getExamples().size();
+
+    if (ApiVendor.OAS_20.equals(apiVendor)) {
+      assertEquals(0, exampleCount);
     } else {
-      assertEquals(0, queryParams.get(AUTHOR_QUERY_PARAM).getExamples().size());
+      assertEquals(2, exampleCount);
     }
   }
 
@@ -329,7 +327,8 @@ public class ParameterImplTest {
   public void fileParameterWithoutValues() {
     List<Parameter> parameters = formParameters.get("second");
     Optional<FileProperties> fileProperties = parameters.get(0).getFileProperties();
-    if (fileProperties.isPresent()) {
+    if (!ApiVendor.OAS_30.equals(apiVendor)) {
+      assertTrue(fileProperties.isPresent());
       FileProperties props = fileProperties.get();
       assertThat(props.getMinLength(), equalTo(0));
       assertThat(props.getMaxLength(), equalTo(0));

--- a/interface-impl-amf/src/test/resources/org/mule/amf/impl/10-query-parameters/api.raml
+++ b/interface-impl-amf/src/test/resources/org/mule/amf/impl/10-query-parameters/api.raml
@@ -64,6 +64,8 @@ types:
         displayName: ISBN
         type: string
         minLength: 10
+        maxLength: 17
+        pattern: ^[-\d]*$
         example: '0321736079'
       tags:
         displayName: Tags

--- a/interface-impl-amf/src/test/resources/org/mule/amf/impl/oas20-query-parameters/api.yaml
+++ b/interface-impl-amf/src/test/resources/org/mule/amf/impl/oas20-query-parameters/api.yaml
@@ -91,6 +91,8 @@ paths:
           in: query
         - name: isbn
           minLength: 10
+          maxLength: 17
+          pattern: ^[-\d]*$
           type: string
           in: query
           required: true

--- a/interface-impl-amf/src/test/resources/org/mule/amf/impl/oas30-query-parameters/api.yaml
+++ b/interface-impl-amf/src/test/resources/org/mule/amf/impl/oas30-query-parameters/api.yaml
@@ -80,6 +80,8 @@ paths:
           required: true
           schema:
             minLength: 10
+            maxLength: 17
+            pattern: ^[-\d]*$
             type: string
             example: '0321736079'
         - name: tags


### PR DESCRIPTION
Based on previous work at #393 by @juanchib

**A design question:** Should we also expose the list of validation errors to the mule error handling mechanism? It doesn't look difficult but I'm not sure if that's a good idea or not.