### PR TITLE
W-12113783: : Return all validation errors instead of just the first one (cherry pick)

### DIFF
--- a/interface-impl-amf/src/main/java/org/mule/amf/impl/model/ParameterImpl.java
+++ b/interface-impl-amf/src/main/java/org/mule/amf/impl/model/ParameterImpl.java
@@ -104,11 +104,12 @@ class ParameterImpl implements Parameter {
   }
 
   private String getErrorMessageFromReport(AMFValidationReport validationReport) {
-    return validationReport.conforms() ? "OK"
-        : validationReport.results().stream()
-            .findFirst()
+    return validationReport.conforms()
+        ? "OK"
+        : validationReport.results()
+            .stream()
             .map(AMFValidationResult::message)
-            .orElse("Error");
+            .collect(joining("\n"));
   }
 
   @Override

--- a/interface-impl-amf/src/test/resources/org/mule/amf/impl/10-query-parameters/api.raml
+++ b/interface-impl-amf/src/test/resources/org/mule/amf/impl/10-query-parameters/api.raml
@@ -64,6 +64,8 @@ types:
         displayName: ISBN
         type: string
         minLength: 10
+        maxLength: 17
+        pattern: ^[-\d]*$
         example: '0321736079'
       tags:
         displayName: Tags

--- a/interface-impl-amf/src/test/resources/org/mule/amf/impl/oas20-query-parameters/api.yaml
+++ b/interface-impl-amf/src/test/resources/org/mule/amf/impl/oas20-query-parameters/api.yaml
@@ -91,6 +91,8 @@ paths:
           in: query
         - name: isbn
           minLength: 10
+          maxLength: 17
+          pattern: ^[-\d]*$
           type: string
           in: query
           required: true

--- a/interface-impl-amf/src/test/resources/org/mule/amf/impl/oas30-query-parameters/api.yaml
+++ b/interface-impl-amf/src/test/resources/org/mule/amf/impl/oas30-query-parameters/api.yaml
@@ -80,6 +80,8 @@ paths:
           required: true
           schema:
             minLength: 10
+            maxLength: 17
+            pattern: ^[-\d]*$
             type: string
             example: '0321736079'
         - name: tags


### PR DESCRIPTION
🍒 for #406

* W-12113783: Remove unneeded ApiVendor assertions from tests
* W-12113783: When AMF reports multiple errors concatenate them using newlines