### PR TITLE
W-12687160: Avoid keeping document reference in memory

### DIFF
--- a/interface-impl-amf/src/main/java/org/mule/amf/impl/AMFParser.java
+++ b/interface-impl-amf/src/main/java/org/mule/amf/impl/AMFParser.java
@@ -22,7 +22,6 @@ import org.mule.apikit.validation.ApiValidationReport;
 import org.mule.apikit.validation.ApiValidationResult;
 import org.mule.apikit.validation.DefaultApiValidationReport;
 
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -33,8 +32,6 @@ import static java.util.stream.Collectors.toList;
 
 public class AMFParser implements ApiParser {
 
-
-  private URI apiUri;
   private ApiReference apiRef;
   private AMFParserWrapper parser;
   private LazyValue<WebApi> webApi;
@@ -60,12 +57,11 @@ public class AMFParser implements ApiParser {
   }
 
   private void initializeParser(ApiReference apiRef, ExecutionEnvironment executionEnvironment) {
+    this.apiRef = apiRef;
     this.executionEnvironment = executionEnvironment;
-    this.apiUri = apiRef.getPathAsUri();
+    this.parser = getParser(apiRef, executionEnvironment);
     this.document = new LazyValue<>(() -> parser.parseApi());
     this.webApi = new LazyValue<>(() -> (WebApi) document.get().encodes());
-    this.apiRef = apiRef;
-    this.parser = getParser(apiRef, executionEnvironment);
   }
 
   public static AMFParserWrapper getParser(ApiReference apiRef, ExecutionEnvironment execEnv) {
@@ -112,11 +108,11 @@ public class AMFParser implements ApiParser {
 
   @Override
   public ApiSpecification parse() {
-    // We are forced to create a brand new environment so this object (and therefore the original document) is not referenced
+    // We are forced to create a brand-new environment so this object (and therefore the original document) is not referenced
     // anymore
     AMFParserWrapper parserWrapper = getParser(apiRef, executionEnvironment);
-    return new AMFImpl(webApi.get(), getReferences(document.get().references()), parserWrapper, apiRef.getVendor(),
-                       apiRef.getLocation(), apiUri);
+    return new AMFImpl(webApi.get(), getReferences(document.get().references()), apiRef.getVendor(),
+                       apiRef.getLocation(), parserWrapper);
   }
 
 }

--- a/interface-impl-amf/src/main/java/org/mule/amf/impl/parser/factory/AMFParserWrapper.java
+++ b/interface-impl-amf/src/main/java/org/mule/amf/impl/parser/factory/AMFParserWrapper.java
@@ -11,7 +11,6 @@ import amf.apicontract.client.platform.AMFConfiguration;
 import amf.apicontract.client.platform.APIConfiguration;
 import amf.core.client.common.transform.PipelineId;
 import amf.core.client.platform.AMFParseResult;
-import amf.core.client.platform.config.RenderOptions;
 import amf.core.client.platform.execution.ExecutionEnvironment;
 import amf.core.client.platform.model.document.BaseUnit;
 import amf.core.client.platform.model.document.Document;
@@ -21,7 +20,6 @@ import org.mule.amf.impl.exceptions.ParserException;
 import org.mule.amf.impl.loader.ExchangeDependencyResourceLoader;
 import org.mule.amf.impl.loader.ProvidedResourceLoader;
 import org.mule.apikit.model.api.ApiReference;
-import org.yaml.builder.JsonOutputBuilder;
 
 import java.io.File;
 import java.net.URI;
@@ -31,41 +29,40 @@ import java.util.concurrent.CompletableFuture;
 
 public class AMFParserWrapper {
 
-
-  private final BaseUnit model;
-  private final AMFBaseUnitClient client;
-  private final List<AMFValidationResult> parsingIssues;
-  private final AMFConfiguration amfConfiguration;
-
+  private final ApiReference apiRef;
+  private final ExecutionEnvironment executionEnvironment;
+  private AMFBaseUnitClient client;
+  private List<AMFValidationResult> parsingIssues;
+  private AMFConfiguration amfConfiguration;
 
   public AMFParserWrapper(ApiReference apiRef, ExecutionEnvironment execEnv) {
-    AMFConfiguration amfConfiguration = APIConfiguration
+    this.apiRef = apiRef;
+    this.executionEnvironment = execEnv;
+    this.amfConfiguration = APIConfiguration
         .API()
         .withExecutionEnvironment(execEnv);
 
     if (apiRef.getResourceLoader().isPresent()) {
-      amfConfiguration = amfConfiguration.withResourceLoader(new ProvidedResourceLoader(apiRef.getResourceLoader().get()));
+      this.amfConfiguration = amfConfiguration.withResourceLoader(new ProvidedResourceLoader(apiRef.getResourceLoader().get()));
     }
     URI apiUri = apiRef.getPathAsUri();
 
     if (apiUri.getScheme() != null && apiUri.getScheme().startsWith("file")) {
       final File file = new File(apiUri);
       final String rootDir = file.isDirectory() ? file.getPath() : file.getParent();
-      amfConfiguration = amfConfiguration.withResourceLoader(new ExchangeDependencyResourceLoader(rootDir, execEnv));
+      this.amfConfiguration = amfConfiguration.withResourceLoader(new ExchangeDependencyResourceLoader(rootDir, execEnv));
     }
-
-    AMFParseResult amfParseResult = handleFuture(amfConfiguration.baseUnitClient()
-        .parse(URLDecoder.decode(apiRef.getPathAsUri().toString())));
-    this.parsingIssues = amfParseResult.results();
-    this.model = amfParseResult.baseUnit();
-    this.amfConfiguration = APIConfiguration.fromSpec(amfParseResult.sourceSpec()).withExecutionEnvironment(execEnv);
-    this.client = this.amfConfiguration.baseUnitClient();
   }
 
   public Document parseApi() throws ParserException {
+    AMFParseResult amfParseResult = handleFuture(amfConfiguration.baseUnitClient()
+        .parse(URLDecoder.decode(apiRef.getPathAsUri().toString())));
+    this.parsingIssues = amfParseResult.results();
+    BaseUnit model = amfParseResult.baseUnit();
+    this.amfConfiguration = APIConfiguration.fromSpec(amfParseResult.sourceSpec()).withExecutionEnvironment(executionEnvironment);
+    this.client = this.amfConfiguration.baseUnitClient();
     return (Document) client.transform(model, PipelineId.Editing()).baseUnit();
   }
-
 
   public AMFValidationReport getParsingReport(Document resolvedDoc) throws ParserException {
     return handleFuture(client.validate(resolvedDoc));
@@ -84,22 +81,6 @@ public class AMFParserWrapper {
 
   private static ParserException getParseException(Exception e) {
     throw new ParserException("An error happened while parsing the api. Message: " + e.getMessage(), e);
-  }
-
-  public String renderApi(Document document) {
-    return getRenderClient().render(document);
-  }
-
-  public AMFBaseUnitClient getRenderClient() {
-    RenderOptions renderOptions = new RenderOptions()
-        .withoutSourceMaps()
-        .withoutPrettyPrint()
-        .withCompactUris();
-    return getAMFConfiguration().withRenderOptions(renderOptions).baseUnitClient();
-  }
-
-  public <W> void renderApi(Document document, JsonOutputBuilder<W> wJsonOutputBuilder) {
-    getRenderClient().renderGraphToBuilder(document, wJsonOutputBuilder);
   }
 
   public AMFConfiguration getAMFConfiguration() {


### PR DESCRIPTION
Gets rid of `BaseUnit` reference in `AMFParserWrapper` by moving the actual parsing to `AMFParserWrapper#parseApi()`.
This is not harmful as all the calls to `AMFParserWrapper#parseApi()` are done in the context of a `LazyValue`.