### PR TITLE
W-14306521: Bump org.json

### DIFF
--- a/interface-impl-amf/pom.xml
+++ b/interface-impl-amf/pom.xml
@@ -28,18 +28,6 @@
             <artifactId>raml-parser-interface</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>com.googlecode.json-simple</groupId>
-            <artifactId>json-simple</artifactId>
-            <version>${json-simple.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
 
         <!-- AMF Dependencies -->
         <dependency>

--- a/interface-impl-amf/pom.xml
+++ b/interface-impl-amf/pom.xml
@@ -39,17 +39,6 @@
             <groupId>org.mule.amf</groupId>
             <artifactId>amf-xml-extension_2.12</artifactId>
             <version>${amf.xml.extension.version}</version>
-            <exclusions>
-                <exclusion>
-                    <artifactId>icu4j</artifactId>
-                    <groupId>com.ibm.icu</groupId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>com.ibm.icu</groupId>
-            <artifactId>icu4j</artifactId>
-            <version>71.1</version>
         </dependency>
         <!-- Tests -->
         <dependency>

--- a/interface-impl-amf/pom.xml
+++ b/interface-impl-amf/pom.xml
@@ -17,8 +17,7 @@
         <licensePath>../LICENSE_HEADER.txt</licensePath>
         <formatterConfigPath>../formatter.xml</formatterConfigPath>
         <sonar.jacoco.reportPaths>../target/jacoco.exec</sonar.jacoco.reportPaths>
-	<!-- NOTE: Please check if the dependency bump on the main pom is still needed after updating AMF -->
-        <amf.version>5.4.2-3</amf.version>
+        <amf.version>5.4.4</amf.version>
         <amf.xml.extension.version>2.0.3</amf.xml.extension.version>
         <json-simple.version>1.1.1</json-simple.version>
     </properties>

--- a/interface-impl-amf/pom.xml
+++ b/interface-impl-amf/pom.xml
@@ -17,7 +17,7 @@
         <licensePath>../LICENSE_HEADER.txt</licensePath>
         <formatterConfigPath>../formatter.xml</formatterConfigPath>
         <sonar.jacoco.reportPaths>../target/jacoco.exec</sonar.jacoco.reportPaths>
-	<!-- NOTE: Please remove the dependency bump once after updating AMF -->
+	<!-- NOTE: Please check if the dependency bump on the main pom is still needed after updating AMF -->
         <amf.version>5.4.2-3</amf.version>
         <amf.xml.extension.version>2.0.3</amf.xml.extension.version>
         <json-simple.version>1.1.1</json-simple.version>

--- a/interface-impl-amf/pom.xml
+++ b/interface-impl-amf/pom.xml
@@ -17,6 +17,7 @@
         <licensePath>../LICENSE_HEADER.txt</licensePath>
         <formatterConfigPath>../formatter.xml</formatterConfigPath>
         <sonar.jacoco.reportPaths>../target/jacoco.exec</sonar.jacoco.reportPaths>
+	<!-- NOTE: Please remove the dependency bump once after updating AMF -->
         <amf.version>5.4.2-3</amf.version>
         <amf.xml.extension.version>2.0.3</amf.xml.extension.version>
         <json-simple.version>1.1.1</json-simple.version>

--- a/interface-impl-amf/src/test/java/org/mule/amf/impl/model/ParameterImplTest.java
+++ b/interface-impl-amf/src/test/java/org/mule/amf/impl/model/ParameterImplTest.java
@@ -174,6 +174,7 @@ public class ParameterImplTest {
     assertTrue(parameter.validate("Test:%20Test"));
     assertTrue(parameter.validate("Test%3A%20Test"));
     assertTrue(parameter.validate("*qwerty*qwerty*"));
+    assertTrue(parameter.validate("\0\u0001\u001f"));
   }
 
   @Test
@@ -195,6 +196,7 @@ public class ParameterImplTest {
     validateArrayValue(nullableArray, nonNullableArray, asList("Test:%20Test"));
     validateArrayValue(nullableArray, nonNullableArray, asList("Test%3A%20Test"));
     validateArrayValue(nullableArray, nonNullableArray, asList("*qwerty*qwerty*", null));
+    validateArrayValue(nullableArray, nonNullableArray, asList("\0\u0001\u001f"));
     if (!ApiVendor.OAS_20.equals(apiVendor)) {
       assertTrue(nullableArray.validateArray(null));
     }
@@ -317,6 +319,30 @@ public class ParameterImplTest {
     assertEquals(value, queryParams.get(RATING_QUERY_PARAM).surroundWithQuotesIfNeeded(value));
     value = "true";
     assertEquals(value, queryParams.get(BORROWED_QUERY_PARAM).surroundWithQuotesIfNeeded(value));
+  }
+
+  @Test
+  public void surroundWithQuotesIfNeededDoesShortEscapes() {
+    final Parameter param = testNullQueryParams.get("nonNullableString");
+    String value = "Hello\"World\\this\bis\fa\nreally\rdumb\ttest/";
+    String escaped = "\"Hello\\\"World\\\\this\\bis\\fa\\nreally\\rdumb\\ttest/\"";
+    assertEquals(escaped, param.surroundWithQuotesIfNeeded(value));
+  }
+
+  @Test
+  public void surroundWithQuotesIfNeededDoesEscapesControlCodes() {
+    final Parameter param = testNullQueryParams.get("nonNullableString");
+    String value = "\0\u0001\u001f";
+    String escaped = "\"\\u0000\\u0001\\u001F\"";
+    assertEquals(escaped, param.surroundWithQuotesIfNeeded(value));
+  }
+
+  @Test
+  public void surroundWithQuotesIfNeededSupportsNonASCIICodepoints() {
+    final Parameter param = testNullQueryParams.get("nonNullableString");
+    String value = "áéíóúñü�𝄞";
+    String escaped = "\"áéíóúñü�𝄞\"";
+    assertEquals(escaped, param.surroundWithQuotesIfNeeded(value));
   }
 
   @Test

--- a/interface-impl-v2/pom.xml
+++ b/interface-impl-v2/pom.xml
@@ -32,6 +32,24 @@
             <artifactId>raml-parser-interface</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.mule.runtime</groupId>
+            <artifactId>mule-metadata-model-json</artifactId>
+            <version>${mule.metadata.api.version}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
-
+    <dependencyManagement>
+        <dependencies>
+            <!-- W-14306521: Bump because the version provided by mule-metadata-model-json is too old. -->
+            <!-- This is a cosmetic bump in order to alleviate false positives by static analysis tools. It does not -->
+            <!-- affect the org.json version used by mule-metadata-model-json during execution (that will be decided -->
+            <!-- by the mule runtime). -->
+            <dependency>
+                <artifactId>json</artifactId>
+                <groupId>org.json</groupId>
+                <version>20231013</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -55,12 +55,6 @@
             <version>${mule.metadata.api.version}</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.mule.runtime</groupId>
-            <artifactId>mule-metadata-model-json</artifactId>
-            <version>${mule.metadata.api.version}</version>
-            <scope>provided</scope>
-        </dependency>
 
         <!-- Tests -->
         <dependency>
@@ -88,18 +82,6 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <dependencyManagement>
-        <dependencies>
-            <!-- W-14306521: Temporary bump until AMF updates their dependency on org.json -->
-            <!-- Maybe also needed to bump the org.json dependency on org.mule.runtime:mule-metadata-model-json -->
-            <dependency>
-                <artifactId>json</artifactId>
-                <groupId>org.json</groupId>
-                <version>20231013</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,6 @@
 
         <jackson.databind.version>2.15.2</jackson.databind.version>
         <guava.version>32.1.0-jre</guava.version>
-        <json.version>20230227</json.version>
         <hamcrestVersion>1.3</hamcrestVersion>
         <junit.version>4.13.2</junit.version>
         <jacoco.version>0.8.5</jacoco.version>
@@ -51,11 +50,6 @@
             <version>${guava.version}</version>
         </dependency>
         <dependency>
-            <artifactId>json</artifactId>
-            <groupId>org.json</groupId>
-            <version>${json.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.mule.runtime</groupId>
             <artifactId>mule-metadata-model-api</artifactId>
             <version>${mule.metadata.api.version}</version>
@@ -66,12 +60,6 @@
             <artifactId>mule-metadata-model-json</artifactId>
             <version>${mule.metadata.api.version}</version>
             <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <artifactId>json</artifactId>
-                    <groupId>org.json</groupId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- Tests -->
@@ -100,6 +88,18 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- W-14306521: Temporary bump until AMF updates their dependency on org.json -->
+            <!-- Maybe also needed to bump the org.json dependency on org.mule.runtime:mule-metadata-model-json -->
+            <dependency>
+                <artifactId>json</artifactId>
+                <groupId>org.json</groupId>
+                <version>20231013</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <build>
         <plugins>

--- a/raml-parser-interface/src/main/java/org/mule/apikit/model/Action.java
+++ b/raml-parser-interface/src/main/java/org/mule/apikit/model/Action.java
@@ -11,8 +11,6 @@ import org.mule.apikit.model.parameter.Parameter;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.commons.collections.MapUtils.isEmpty;
-
 public interface Action {
 
   ActionType getType();
@@ -55,7 +53,7 @@ public interface Action {
 
   default String getSuccessStatusCode() {
     Map<String, Response> responses = getResponses();
-    if (isEmpty(responses) || responses.get("default") != null) {
+    if (responses == null || responses.isEmpty() || responses.get("default") != null) {
       return "200";
     }
     for (String status : responses.keySet()) {


### PR DESCRIPTION
This PR removes our direct dependency on `org.json` (we were using just an escaping static method that is now rewritten). And overrides the dependency via `dependencyManagement` until fixed versions of our dependencies are released.

For reference this is the railroad diagram for JSON strings:
![Railroad diagram for JSON strings, it explains how characters should be escaped](https://www.json.org/img/string.png)