### PR TITLE
[W-18503293]Adding min max in parameters for validation in rest amf parser

### DIFF
--- a/interface-impl-amf/src/main/java/org/mule/amf/impl/model/ParameterImpl.java
+++ b/interface-impl-amf/src/main/java/org/mule/amf/impl/model/ParameterImpl.java
@@ -59,6 +59,25 @@ class ParameterImpl implements Parameter {
   private Set<String> allowedEncoding;
   private boolean required;
 
+  public int getMaxItems() {
+    return maxItems;
+  }
+
+  public void setMaxItems(int maxItems) {
+    this.maxItems = maxItems;
+  }
+
+  public int getMinItems() {
+    return minItems;
+  }
+
+  public void setMinItems(int minItems) {
+    this.minItems = minItems;
+  }
+
+  private int minItems;
+  private int maxItems;
+
   private LazyValue<List<String>> defaultValues;
 
   private LazyValue<Boolean> isArray = new LazyValue<>(() -> schema instanceof ArrayShape ||

--- a/interface-impl-amf/src/main/java/org/mule/amf/impl/model/ParameterImpl.java
+++ b/interface-impl-amf/src/main/java/org/mule/amf/impl/model/ParameterImpl.java
@@ -7,7 +7,6 @@
 package org.mule.amf.impl.model;
 
 import amf.apicontract.client.platform.AMFConfiguration;
-import amf.core.client.platform.model.IntField;
 import amf.core.client.platform.model.StrField;
 import amf.core.client.platform.model.domain.ArrayNode;
 import amf.core.client.platform.model.domain.DataNode;
@@ -306,18 +305,18 @@ class ParameterImpl implements Parameter {
   }
 
   @Override
-  public Integer getMaxItems() {
-    if (!(schema instanceof ArrayShape)) {
-      return null;
+  public Optional<Integer> getMaxItems() {
+    if (schema instanceof ArrayShape && ((ArrayShape) schema).maxItems().nonNull()) {
+      return Optional.of(((ArrayShape) schema).maxItems().value());
     }
-    return ((ArrayShape) schema).maxItems().value();
+    return Optional.empty();
   }
 
   @Override
-  public Integer getMinItems() {
-    if (!(schema instanceof ArrayShape)) {
-      return null;
+  public Optional<Integer> getMinItems() {
+    if (schema instanceof ArrayShape && ((ArrayShape) schema).minItems().nonNull()) {
+      return Optional.of(((ArrayShape) schema).minItems().value());
     }
-    return ((ArrayShape) schema).minItems().value();
+    return Optional.empty();
   }
 }

--- a/interface-impl-amf/src/main/java/org/mule/amf/impl/model/ParameterImpl.java
+++ b/interface-impl-amf/src/main/java/org/mule/amf/impl/model/ParameterImpl.java
@@ -7,6 +7,7 @@
 package org.mule.amf.impl.model;
 
 import amf.apicontract.client.platform.AMFConfiguration;
+import amf.core.client.platform.model.IntField;
 import amf.core.client.platform.model.StrField;
 import amf.core.client.platform.model.domain.ArrayNode;
 import amf.core.client.platform.model.domain.DataNode;
@@ -58,25 +59,6 @@ class ParameterImpl implements Parameter {
   private AnyShape schema;
   private Set<String> allowedEncoding;
   private boolean required;
-
-  public int getMaxItems() {
-    return maxItems;
-  }
-
-  public void setMaxItems(int maxItems) {
-    this.maxItems = maxItems;
-  }
-
-  public int getMinItems() {
-    return minItems;
-  }
-
-  public void setMinItems(int minItems) {
-    this.minItems = minItems;
-  }
-
-  private int minItems;
-  private int maxItems;
 
   private LazyValue<List<String>> defaultValues;
 
@@ -321,5 +303,21 @@ class ParameterImpl implements Parameter {
       return values;
     }
     return emptyList();
+  }
+
+  @Override
+  public Integer getMaxItems() {
+    if (!(schema instanceof ArrayShape)) {
+      return null;
+    }
+    return ((ArrayShape) schema).maxItems().value();
+  }
+
+  @Override
+  public Integer getMinItems() {
+    if (!(schema instanceof ArrayShape)) {
+      return null;
+    }
+    return ((ArrayShape) schema).minItems().value();
   }
 }

--- a/interface-impl-amf/src/test/java/org/mule/amf/impl/model/ParameterImplTest.java
+++ b/interface-impl-amf/src/test/java/org/mule/amf/impl/model/ParameterImplTest.java
@@ -49,12 +49,14 @@ public class ParameterImplTest {
   private static final String TEST_NULL_RESOURCE = "/testNull";
   private static final String MULTIPART_DOCUMENTS = "/documents";
   private static final String RESOURCE_DYNAMIC_FILES = "/dynamic-files";
+  private static final String MULTIPART_UPLOAD = "/multipart-upload";
   private static final String ACTION_POST = "POST";
   private static final String MULTIPART_CONTENT_TYPE = "multipart/form-data";
 
   private static Map<String, Parameter> queryParams;
   private static Map<String, Parameter> testNullQueryParams;
   private static Map<String, List<Parameter>> formParameters;
+  private static Map<String, List<Parameter>> arrayShapeFormParameters;
   private Map<String, List<Parameter>> fileArrayParameterInForm;
 
   @Parameterized.Parameter
@@ -94,6 +96,8 @@ public class ParameterImplTest {
         .getBody().get(MULTIPART_CONTENT_TYPE).getFormParameters();
     fileArrayParameterInForm = apiSpecification.getResource(RESOURCE_DYNAMIC_FILES).getAction(ACTION_POST)
         .getBody().get(MULTIPART_CONTENT_TYPE).getFormParameters();
+    arrayShapeFormParameters = apiSpecification.getResource(MULTIPART_UPLOAD).getAction(ACTION_POST)
+            .getBody().get(MULTIPART_CONTENT_TYPE).getFormParameters();
   }
 
   @Test
@@ -379,6 +383,21 @@ public class ParameterImplTest {
       assertThat(props.getMinLength(), equalTo(0));
       assertThat(props.getMaxLength(), equalTo(0));
       assertThat(props.getFileTypes().isEmpty(), equalTo(true));
+    }
+  }
+
+  @Test
+  public void arrayShapeParameters() {
+    List<Parameter> parameters = arrayShapeFormParameters.get("Attachments");
+    Parameter parameter = parameters.get(0);
+    Optional<FileProperties> fileProperties = parameter.getFileProperties();
+    if (!ApiVendor.OAS_30.equals(apiVendor)) {
+      assertTrue(fileProperties.isPresent());
+      FileProperties props = fileProperties.get();
+      assertThat(props.getMinLength(), equalTo(0));
+      assertThat(props.getMaxLength(), equalTo(5242880));
+      assertTrue(parameter.getMinItems().isPresent() && parameter.getMinItems().get().equals(2));
+      assertTrue(parameter.getMaxItems().isPresent() && parameter.getMaxItems().get().equals(3));
     }
   }
 

--- a/interface-impl-amf/src/test/java/org/mule/amf/impl/model/ParameterImplTest.java
+++ b/interface-impl-amf/src/test/java/org/mule/amf/impl/model/ParameterImplTest.java
@@ -402,6 +402,16 @@ public class ParameterImplTest {
   }
 
   @Test
+  public void fileShapeParameters() {
+    List<Parameter> parameters = formParameters.get("second");
+    Parameter parameter = parameters.get(0);
+    if (!ApiVendor.OAS_30.equals(apiVendor)) {
+      assertFalse(parameter.getMinItems().isPresent());
+      assertFalse(parameter.getMaxItems().isPresent());
+    }
+  }
+
+  @Test
   public void fileArrayParameter() {
     List<Parameter> parameters = fileArrayParameterInForm.get("files");
     FileProperties fileProperties = parameters.get(0).getFileProperties().get();

--- a/interface-impl-amf/src/test/java/org/mule/amf/impl/model/ParameterImplTest.java
+++ b/interface-impl-amf/src/test/java/org/mule/amf/impl/model/ParameterImplTest.java
@@ -97,7 +97,7 @@ public class ParameterImplTest {
     fileArrayParameterInForm = apiSpecification.getResource(RESOURCE_DYNAMIC_FILES).getAction(ACTION_POST)
         .getBody().get(MULTIPART_CONTENT_TYPE).getFormParameters();
     arrayShapeFormParameters = apiSpecification.getResource(MULTIPART_UPLOAD).getAction(ACTION_POST)
-            .getBody().get(MULTIPART_CONTENT_TYPE).getFormParameters();
+        .getBody().get(MULTIPART_CONTENT_TYPE).getFormParameters();
   }
 
   @Test

--- a/interface-impl-amf/src/test/resources/org/mule/amf/impl/10-query-parameters/api.raml
+++ b/interface-impl-amf/src/test/resources/org/mule/amf/impl/10-query-parameters/api.raml
@@ -10,6 +10,10 @@ types:
   DynamicFiles:
     type: file
     fileTypes: [ 'application/octet-stream','image/jpeg','image/png' ]
+  Attachment:
+    type: file
+    fileTypes: ['application/pdf', 'image/jpeg', 'image/png', 'text/plain']
+    maxLength: 5242880  # 5 MB
 
 /testNull:
   get:
@@ -111,3 +115,16 @@ types:
         properties:
           files:
             type: DynamicFiles[]
+
+/multipart-upload:
+  post:
+    description: Upload an array of files and a JSON array as multipart/form-data
+    body:
+      multipart/form-data:
+        properties:
+          Attachments:
+            description: Array of files
+            type: Attachment[]
+            required: true
+            minItems: 2
+            maxItems: 3

--- a/interface-impl-amf/src/test/resources/org/mule/amf/impl/oas20-query-parameters/api.yaml
+++ b/interface-impl-amf/src/test/resources/org/mule/amf/impl/oas20-query-parameters/api.yaml
@@ -160,3 +160,22 @@ paths:
           type: array
           items:
             type: file
+  /multipart-upload:
+    post:
+      operationId: Multipart_Upload
+      responses:
+        default:
+          description: ''
+      consumes:
+        - multipart/form-data
+      parameters:
+        - name: Attachments
+          in: formData
+          description: Array of files
+          type: array
+          items:
+            type: file
+            maxLength: 5242880  # 5 MB
+          required: true
+          minItems: 2
+          maxItems: 3

--- a/interface-impl-amf/src/test/resources/org/mule/amf/impl/oas30-query-parameters/api.yaml
+++ b/interface-impl-amf/src/test/resources/org/mule/amf/impl/oas30-query-parameters/api.yaml
@@ -155,6 +155,31 @@ paths:
               files:
                 contentType: application/octet-stream, image/jpeg, image/png
         required: true
+  /multipart-upload:
+    post:
+      responses:
+        default:
+          description: ''
+      operationId: Multipart_Upload
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                Attachments:
+                  type: array
+                  minItems: 2
+                  maxItems: 3
+                  items:
+                    type: file
+                    maxLength: 5242880  # 5 MB
+              required:
+                - Attachments
+            encoding:
+              Attachments:
+                contentType: text/plain, image/jpeg
+        required: true
 components:
   schemas:
     author:

--- a/interface-impl-v2/src/test/java/org/mule/apikit/implv2/v10/model/ParameterImplTest.java
+++ b/interface-impl-v2/src/test/java/org/mule/apikit/implv2/v10/model/ParameterImplTest.java
@@ -185,4 +185,12 @@ public class ParameterImplTest {
     assertFalse(queryParams.get(AUTHOR_QUERY_PARAM).getFileProperties().isPresent());
   }
 
+  @Test
+  public void fileShapeParameter() {
+    List<Parameter> parameters = fileArrayParameterInForm.get("files");
+    Parameter parameter = parameters.get(0);
+    assertFalse(parameter.getMaxItems().isPresent());
+    assertFalse(parameter.getMinItems().isPresent());
+  }
+
 }

--- a/raml-parser-interface/src/main/java/org/mule/apikit/model/parameter/Parameter.java
+++ b/raml-parser-interface/src/main/java/org/mule/apikit/model/parameter/Parameter.java
@@ -70,4 +70,12 @@ public interface Parameter {
    * @since 2.4.0
    */
   boolean isNullable();
+
+  default Integer getMaxItems() {
+    return null;
+  }
+
+  default Integer getMinItems() {
+    return null;
+  }
 }

--- a/raml-parser-interface/src/main/java/org/mule/apikit/model/parameter/Parameter.java
+++ b/raml-parser-interface/src/main/java/org/mule/apikit/model/parameter/Parameter.java
@@ -71,11 +71,11 @@ public interface Parameter {
    */
   boolean isNullable();
 
-  default Integer getMaxItems() {
-    return null;
+  default Optional<Integer> getMaxItems() {
+    return Optional.empty();
   }
 
-  default Integer getMinItems() {
-    return null;
+  default Optional<Integer> getMinItems() {
+    return Optional.empty();
   }
 }


### PR DESCRIPTION
Add support for minItems/maxItems properties for ArrayShape in AMF parser validation.
WI created for similar validation support in RAML parser
https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002ElNl3YAF/view